### PR TITLE
Vault-based certificate store

### DIFF
--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -7,12 +7,13 @@ dynamic_resources:
   lds_config:
     api_config_source:
       api_type: REST
-      cluster_name: [xds_cluster]
+      # NOTE: "cluster_name" field pluralised in an unreleased version of Envoy
+      cluster_names: [xds_cluster]
       refresh_delay: 30s
   cds_config:
     api_config_source:
       api_type: REST
-      cluster_name: [xds_cluster]
+      cluster_names: [xds_cluster]
       refresh_delay: 30s
 
 static_resources:
@@ -23,6 +24,6 @@ static_resources:
     lb_policy: ROUND_ROBIN
     http_protocol_options: {}
     # This address needs to be updated with the address to reach the Flask app
-    # Hint: With Docker bridge-mode networking with very default settings on Linux,
-    # the address can be set to 172.17.0.1 to reach the host.
+    # Hint: With Docker bridge-mode networking with very default settings on
+    # Linux, the address can be set to 172.17.0.1 to reach the host.
     hosts: [{ socket_address: { address: 127.0.0.1, port_value: 5000 }}]

--- a/marathon_envoy_poc/app.py
+++ b/marathon_envoy_poc/app.py
@@ -253,6 +253,8 @@ def _get_cached_cert(domain, cert_id):
         # when storing. Doesn't really matter if the cert we get from Vault
         # doesn't have the right ID, it will hopefully be the right cert when
         # we next try to fetch from Vault.
+        # NOTE: We compare "raw" bytes here. This way, binascii will take of
+        # uppercase vs lowercase hex encoding.
         if get_cert_fingerprint(cached_certs) == binascii.dehexlify(cert_id):
             return cached_certs, cached_key
 

--- a/marathon_envoy_poc/certs.py
+++ b/marathon_envoy_poc/certs.py
@@ -1,0 +1,46 @@
+"""
+Various utilities for working with x509 PEM-encoded certificates.
+"""
+from cryptography.x509 import load_pem_x509_certificate
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import (
+    Encoding, NoEncryption, PrivateFormat, load_pem_private_key)
+
+import pem
+
+
+def get_cert_fingerprint(certs):
+    # Generally the first certificate in the list is the one we want the
+    # fingerprint for. The second cert is the intermediary CA cert.
+    return certs[0].fingerprint(hashes.SHA1())
+
+
+def load_cert_objs(certs_pem_bytes):
+    cert_pems = pem.parse(certs_pem_bytes)
+    if not cert_pems:
+        raise ValueError("Unable to parse any certificate data.")
+
+    return [load_pem_x509_certificate(cert_pem.as_bytes(), default_backend())
+            for cert_pem in cert_pems]
+
+
+def load_key_obj(key_pem_bytes):
+    key_pems = pem.parse(key_pem_bytes)
+    if len(key_pems) != 1:
+        raise ValueError(
+            "Unexpected number of private keys. Expected {}, got {}.".format(
+                1, len(key_pems)))
+
+    # None -> no password
+    return load_pem_private_key(
+        key_pems[0].as_bytes(), None, default_backend())
+
+
+def certs_pem_bytes(cert_objs):
+    return b"".join([cert.public_bytes(Encoding.PEM) for cert in cert_objs])
+
+
+def key_pem_bytes(key_obj):
+    return key_obj.private_bytes(
+        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())

--- a/marathon_envoy_poc/config.py
+++ b/marathon_envoy_poc/config.py
@@ -18,8 +18,15 @@ class _ConfigBase:
     # Seconds between polls of our service
     REFRESH_DELAY = os.environ.get("REFRESH_DELAY", 30)
 
+    VAULT = os.environ.get("VAULT", "http://127.0.0.1:8200")
+    VAULT_TOKEN = os.environ.get("VAULT_TOKEN")
+    MARATHON_ACME_VAULT_PATH = os.environ.get(
+        "MARATHON_ACME_VAULT_PATH", "/secret/marathon-acme")
+
     HTTP_LISTEN_ADDR = os.environ.get("HTTP_LISTEN_ADDR", "0.0.0.0")
     HTTP_LISTEN_PORT = os.environ.get("HTTP_LISTEN_PORT", 80)
+    HTTPS_LISTEN_ADDR = os.environ.get("HTTPS_LISTEN_ADDR", "0.0.0.0")
+    HTTPS_LISTEN_PORT = os.environ.get("HTTPS_LISTEN_PORT", 443)
 
     CLUSTER_CONNECT_TIMEOUT = 5
     CLUSTER_HEALTHCHECK_TIMEOUT = 5

--- a/marathon_envoy_poc/envoy.py
+++ b/marathon_envoy_poc/envoy.py
@@ -1,3 +1,4 @@
+from base64 import b64encode
 import binascii
 
 
@@ -196,8 +197,13 @@ def CommonTlsContext(
             # https://www.envoyproxy.io/docs/envoy/v1.5.0/api-v2/sds.proto.html#tlscertificate
             # NOTE: inline_bytes in DataSource for certs is pending this PR:
             # https://github.com/envoyproxy/envoy/pull/2248
-            "certificate_chain": {"inline_bytes": certificate_chain},
-            "private_key": {"inline_bytes": private_key},
+            "certificate_chain": {
+                # protobuf bytes represented as base64 strings in JSON
+                "inline_bytes": b64encode(certificate_chain).decode("utf-8")
+            },
+            "private_key": {
+                "inline_bytes": b64encode(private_key).decode("utf-8")
+            },
         }],
         # "validation_context": "{...}",
         "alpn_protocols": [alpn_protocols]

--- a/marathon_envoy_poc/vault.py
+++ b/marathon_envoy_poc/vault.py
@@ -1,0 +1,47 @@
+import requests
+
+
+class VaultClient:
+    """
+    World's most basic Vault API client. Can get data from Vault. A real
+    implementation should manage the lease on the Vault token, support custom
+    certs for connecting to Vault, etc.
+    """
+
+    def __init__(self, base_url, token, mount_point="/", client=None):
+        self._base_url = base_url
+        self._token = token
+        self._mount_point = mount_point
+
+        if client is None:
+            client = requests.Session()
+        self._client = client
+
+    def close(self):
+        self._client.close()
+
+    def _request(self, method, path, headers=None, **kwargs):
+        if headers is None:
+            headers = {}
+
+        _headers = {"X-Vault-Token": self._token}
+        _headers.update(headers)
+
+        return self._client.request(
+            method, self._base_url + path, headers=_headers, **kwargs)
+
+    def test(self):
+        assert self._request("HEAD", "/v1/sys/health").status_code == 200
+
+    def get(self, path, **kwargs):
+        response = self._request(
+            "GET", "/v1" + self._mount_point + path, **kwargs)
+
+        if response.status_code == 200:
+            return response.json()["data"]
+        elif response.status_code == 404:
+            return None
+        else:
+            raise RuntimeError(
+                "Unexpected response code {} from {}: {}".format(
+                    response.status_code, path, response.text))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
+        "cryptography",
         "flask",
+        "pem",
         "requests",
     ],
     extras_require={


### PR DESCRIPTION
Store marathon-acme-issued certificates in Vault, retrieve those certs with our xDS and pass them on to Envoy.

This is quite theoretical until marathon-acme also supports this.

Things I still want to do in this PR:
* Some basic validation of certificates

Things I want to do in the next PR:
* TLS between Envoy and this xDS using certs from Vault