### PR TITLE
Use inline_string form of DataSource to prevent extra base64 encoding

### DIFF
--- a/marathon_envoy_poc/app.py
+++ b/marathon_envoy_poc/app.py
@@ -4,7 +4,7 @@ import os
 from flask import Flask, g, jsonify, request
 
 from .certs import (
-    cert_fingerprint, fullchain_pem_bytes, key_pem_bytes, load_cert_obj,
+    cert_fingerprint, fullchain_pem_str, key_pem_str, load_cert_obj,
     load_chain_objs, load_key_obj)
 from .envoy import (
     Cluster, ClusterLoadAssignment, CommonTlsContext, ConfigSource,
@@ -269,10 +269,10 @@ def _get_vault_cert(domain):
         return None
 
     try:
-        return (load_cert_obj(cert["cert"].encode("utf-8")),
+        return (load_cert_obj(cert["cert"]),
                 # Chain certificates optional
-                load_chain_objs(cert.get("chain", "").encode("utf-8")),
-                load_key_obj(cert["privkey"].encode("utf-8")))
+                load_chain_objs(cert.get("chain", "")),
+                load_key_obj(cert["privkey"]))
     except Exception as e:
         flask_app.logger.warn(
             "Error parsing Vault certificate for domain %s: %s", domain, e)
@@ -311,7 +311,7 @@ def get_certificates():
 
     # Finally, map the certificate and key objects back into the right form for
     # use by Envoy
-    return {domain: (fullchain_pem_bytes(certs, chain), key_pem_bytes(key))
+    return {domain: (fullchain_pem_str(certs, chain), key_pem_str(key))
             for domain, (certs, chain, key) in certificates.items()}
 
 

--- a/marathon_envoy_poc/certs.py
+++ b/marathon_envoy_poc/certs.py
@@ -1,5 +1,5 @@
 """
-Various utilities for working with x509 PEM-encoded certificates.
+Tools for converting PEM string data to/from cryptography primitive types.
 """
 from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.backends import default_backend
@@ -14,8 +14,8 @@ def cert_fingerprint(cert):
     return cert.fingerprint(hashes.SHA1())
 
 
-def load_cert_obj(cert_pem_bytes):
-    cert_pems = pem.parse(cert_pem_bytes)
+def load_cert_obj(cert_pem_str):
+    cert_pems = pem.parse(cert_pem_str.encode("utf-8"))
     if len(cert_pems) != 1:
         raise ValueError(
             "Unexpected number of certificates. Expected {}, got {}.".format(
@@ -25,14 +25,14 @@ def load_cert_obj(cert_pem_bytes):
         cert_pems[0].as_bytes(), default_backend())
 
 
-def load_chain_objs(chain_pem_bytes):
+def load_chain_objs(chain_pem_str):
     # 0 or more chain certificates
     return [load_pem_x509_certificate(chain_pem.as_bytes())
-            for chain_pem in pem.parse(chain_pem_bytes)]
+            for chain_pem in pem.parse(chain_pem_str.encode("utf-8"))]
 
 
-def load_key_obj(key_pem_bytes):
-    key_pems = pem.parse(key_pem_bytes)
+def load_key_obj(key_pem_str):
+    key_pems = pem.parse(key_pem_str.encode("utf-8"))
     if len(key_pems) != 1:
         raise ValueError(
             "Unexpected number of private keys. Expected {}, got {}.".format(
@@ -43,14 +43,14 @@ def load_key_obj(key_pem_bytes):
         key_pems[0].as_bytes(), None, default_backend())
 
 
-def cert_pem_bytes(cert_obj):
-    return cert_obj.public_bytes(Encoding.PEM)
+def cert_pem_str(cert_obj):
+    return cert_obj.public_bytes(Encoding.PEM).decode("utf-8")
 
 
-def fullchain_pem_bytes(cert_obj, chain_objs):
-    return b"".join([cert_pem_bytes(cert) for cert in [cert_obj] + chain_objs])
+def fullchain_pem_str(cert_obj, chain_objs):
+    return "".join([cert_pem_str(cert) for cert in [cert_obj] + chain_objs])
 
 
-def key_pem_bytes(key_obj):
+def key_pem_str(key_obj):
     return key_obj.private_bytes(
-        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+        Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode("utf-8")

--- a/marathon_envoy_poc/envoy.py
+++ b/marathon_envoy_poc/envoy.py
@@ -1,4 +1,3 @@
-from base64 import b64encode
 import binascii
 
 
@@ -199,10 +198,10 @@ def CommonTlsContext(
             # https://github.com/envoyproxy/envoy/pull/2248
             "certificate_chain": {
                 # protobuf bytes represented as base64 strings in JSON
-                "inline_bytes": b64encode(certificate_chain).decode("utf-8")
+                "inline_string": certificate_chain
             },
             "private_key": {
-                "inline_bytes": b64encode(private_key).decode("utf-8")
+                "inline_string": private_key
             },
         }],
         # "validation_context": "{...}",


### PR DESCRIPTION
This won't be an issue when we use gRPC, but with the JSON-REST protocol, using `inline_bytes` for the `DataSource` of certificates means we need to do a base64 encoding of certificates...but the certificates are in PEM format which is already a base64-encoded format.

If we send the certs using `inline_string` we can save the extra base64 encoding.