### PR TITLE
Initial TLS setup for xDS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,23 +18,29 @@ Envoy as an "edge" proxy in an attempt to replace marathon-lb.
 
 Usage
 -----
-To give this a try, you will need a running Marathon instance. You can run the
-Flask app using the default Flask server::
+To give this a try, you will need a running Marathon instance and Vault
+instance. You can run the Flask app using the default Flask server::
 
   $ pip install -e .
     [...]
-  $ export FLASK_APP=marathon_envoy_poc
-  $ flask run
+  $ python -m marathon_envoy_poc
   * Serving Flask app "marathon_envoy_poc"
   * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 
-You can adjust the address to the Marathon host using the ``MARATHON``
-environment variable. Several other configuration options can be set using
-environment variables. See the ``config.py`` file for those options.
+You can adjust the address for Marathon using the ``MARATHON`` environment
+variable, and the address for Vault using the ``VAULT`` environment variable.
+Several other configuration options can be set using environment variables. See
+the ``config.py`` file for those options.
+
+Envoy will need a CA certificate from Vault in order to validate the xDS's
+certificate. You can fetch the CA cert using a command like this (this is an
+un-authed Vault endpoint)::
+
+  curl https://myvault.com:8200/v1/pki/ca/pem > vault-ca.pem
 
 Envoy is then most easily run using Docker::
 
-  docker run --rm -it -v "$(pwd)":/mep --net=host envoyproxy/envoy:v1.5.0 \
+  docker run --rm -it -v "$(pwd)":/mep --net=host envoyproxy/envoy:latest \
     envoy -c /mep/bootstrap.yaml --service-node test --service-cluster test
 
 This will use port 80/443 on your machine (or whatever ports the LDS tells
@@ -43,3 +49,16 @@ you can remove the ``--net=host`` argument and add ``-p 9901:9901`` so that
 Envoy's admin interface is still available. You'll also need to update the
 address for the ``xds_cluster`` in ``bootstrap.yaml`` so that Envoy can reach
 the Flask app, wherever you are running it.
+
+Vault setup
+^^^^^^^^^^^
+Setting up Vault takes quite a few steps. Firstly, you will need a Vault policy
+for the xDS to use. Such a policy is provided in the ``vault-policy.hcl`` file.
+
+The xDS uses the PKI backend to get certificates for TLS. This means a PKI role
+must be created that the xDS will use when requesting certificates. By default
+this role is called ``marathon-envoy-poc`` but can be adjusted in the config.
+
+**Note:** This PKI system is currently only used for server-side certificates
+in this proof-of-concept. This means that there is **no authentication of the**
+**client** (Envoy).

--- a/bootstrap.yaml
+++ b/bootstrap.yaml
@@ -27,3 +27,7 @@ static_resources:
     # Hint: With Docker bridge-mode networking with very default settings on
     # Linux, the address can be set to 172.17.0.1 to reach the host.
     hosts: [{ socket_address: { address: 127.0.0.1, port_value: 5000 }}]
+    tls_context:
+      common_tls_context:
+        validation_context:
+          trusted_ca: {filename: vault-ca.pem}

--- a/marathon_envoy_poc/__main__.py
+++ b/marathon_envoy_poc/__main__.py
@@ -1,0 +1,31 @@
+import os
+import ssl
+import tempfile
+
+from marathon_envoy_poc.app import flask_app, issue_vault_cert
+
+
+def _load_cert_data(ssl_context, certdata):
+    # Workaround because Python ssl lib doesn't support in-memory cert loading
+    fd, temp_path = tempfile.mkstemp()
+    try:
+        os.write(fd, certdata.encode("utf-8"))
+        ssl_context.load_cert_chain(temp_path)
+    finally:
+        os.close(fd)
+        os.remove(temp_path)
+
+
+def main():
+    # TODO: Reload cert before it expires
+    with flask_app.app_context():
+        certdata = issue_vault_cert()
+
+    ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    _load_cert_data(ssl_context, certdata)
+
+    flask_app.run(ssl_context=ssl_context)
+
+
+if __name__ == '__main__':
+    main()

--- a/marathon_envoy_poc/config.py
+++ b/marathon_envoy_poc/config.py
@@ -20,8 +20,14 @@ class _ConfigBase:
 
     VAULT = os.environ.get("VAULT", "http://127.0.0.1:8200")
     VAULT_TOKEN = os.environ.get("VAULT_TOKEN")
-    MARATHON_ACME_VAULT_PATH = os.environ.get(
-        "MARATHON_ACME_VAULT_PATH", "/secret/marathon-acme")
+
+    VAULT_PKI_MOUNT = os.environ.get("VAULT_PKI_MOUNT", "pki")
+    VAULT_PKI_ROLE = os.environ.get("VAULT_PKI_ROLE", "marathon-envoy-poc")
+    VAULT_PKI_CN = os.environ.get("VAULT_PKI_CN", "marathon-envoy-poc")
+
+    VAULT_KV_MOUNT = os.environ.get("VAULT_KV_MOUNT", "secret")
+    MARATHON_ACME_KV_PATH = os.environ.get(
+        "MARATHON_ACME_KV_PATH", "marathon-acme")
 
     HTTP_LISTEN_ADDR = os.environ.get("HTTP_LISTEN_ADDR", "0.0.0.0")
     HTTP_LISTEN_PORT = os.environ.get("HTTP_LISTEN_PORT", 80)

--- a/marathon_envoy_poc/vault.py
+++ b/marathon_envoy_poc/vault.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 
 
@@ -8,10 +10,12 @@ class VaultClient:
     certs for connecting to Vault, etc.
     """
 
-    def __init__(self, base_url, token, mount_point="/", client=None):
+    def __init__(self, base_url, token, kv_mount="secret", pki_mount="pki",
+                 client=None):
         self._base_url = base_url
         self._token = token
-        self._mount_point = mount_point
+        self._kv_mount = kv_mount
+        self._pki_mount = pki_mount
 
         if client is None:
             client = requests.Session()
@@ -33,15 +37,35 @@ class VaultClient:
     def test(self):
         assert self._request("HEAD", "/v1/sys/health").status_code == 200
 
-    def get(self, path, **kwargs):
-        response = self._request(
-            "GET", "/v1" + self._mount_point + path, **kwargs)
+    def _get_raw(self, path, **kwargs):
+        response = self._request("GET", "/v1/" + path, **kwargs)
 
         if response.status_code == 200:
-            return response.json()["data"]
+            return response.text
         elif response.status_code == 404:
             return None
         else:
             raise RuntimeError(
                 "Unexpected response code {} from {}: {}".format(
                     response.status_code, path, response.text))
+
+    def get_kv(self, path, **kwargs):
+        raw = self._get_raw("/".join((self._kv_mount, path)), **kwargs)
+        return json.loads(raw)["data"] if raw is not None else None
+
+    def issue_cert(self, role, common_name):
+        json_data = {
+            "common_name": common_name,
+            "format": "pem_bundle",
+            "private_key_format": "pkcs8",
+        }
+        response = self._request(
+            "POST", "/v1/{}/issue/{}".format(self._pki_mount, role),
+            json=json_data)
+
+        if response.status_code == 200:
+            return response.json()["data"]["certificate"]
+        else:
+            raise RuntimeError(
+                "Unexpected response code {} when issuing cert for role {}: {}"
+                .format(response.status_code, role, response.text))

--- a/vault-policy.hcl
+++ b/vault-policy.hcl
@@ -1,0 +1,14 @@
+# Get the marathon-acme certificate list
+path "secret/marathon-acme/live" {
+  capabilities = ["read"]
+}
+
+# Get marathon-acme certificates
+path "secret/marathon-acme/certificates/*" {
+  capabilities = ["read"]
+}
+
+# Issue certificates for ourself (the marathon-envoy-poc role)
+path "pki/issue/marathon-envoy-poc" {
+  capabilities = ["update"]
+}


### PR DESCRIPTION
Use Vault's PKI backend to encrypt connections between Envoy and the xDS.